### PR TITLE
Simplify Android build

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -256,38 +256,11 @@ jobs:
         run: |
           git submodule update --init --recursive
 
-      - name: Setup ubuntu
-        run: |
-          sudo apt-get --quiet update --yes
-          sudo apt-get --quiet install --yes wget tar unzip lib32stdc++6 lib32z1
-
       - name: Configure node
         uses: actions/setup-node@v1
         with:
           node-version: "16.15.0"
           registry-url: "https://registry.npmjs.org"
-
-      - name: Setup JDK 1.8
-        uses: actions/setup-java@v1
-        with:
-          java-version: 1.8
-
-      - name: Download Android SDK
-        working-directory: app/android
-        run: |
-          wget --quiet --output-document=android-sdk.zip https://dl.google.com/android/repository/sdk-tools-linux-${{ matrix.sdk-tools }}.zip
-          unzip -d android-sdk-linux android-sdk.zip
-          sudo mkdir -p /root/.android
-          sudo touch /root/.android/repositories.cfg
-          echo y | android-sdk-linux/tools/bin/sdkmanager "platforms;android-${{ matrix.compile-sdk }}" >/dev/null
-          echo y | android-sdk-linux/tools/bin/sdkmanager "platform-tools" >/dev/null
-          echo y | android-sdk-linux/tools/bin/sdkmanager "build-tools;${{ matrix.build-tools }}" >/dev/null
-          export ANDROID_HOME=$PWD/android-sdk-linux
-          export PATH=$PATH:$PWD/android-sdk-linux/platform-tools/
-          chmod +x ./gradlew
-          set +o pipefail
-          yes | android-sdk-linux/tools/bin/sdkmanager --licenses
-          set -o pipefail
 
       - name: Cache node modules
         uses: actions/cache@v1


### PR DESCRIPTION
I don't think we need to install the Android SDK any longer as it comes installed on the [Ubuntu runner image](https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2204-Readme.md). I've removed it from the BC pipeline and its seems to be working fine. We had to update the SDK for for a feature we needed but I don't think this will impact you. Worth a try.